### PR TITLE
Fix site base url

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -11,7 +11,7 @@ email: do.not@email.me
 description: > # this means to ignore newlines until "baseurl:"
   On software, craft and continuous improvement
 baseurl: "" # the subpath of your site, e.g. /blog
-url: "http://yourdomain.com" # the base hostname & protocol for your site
+url: "http://kevin.yeung.online" # the base hostname & protocol for your site
 github_username:  kcpyeung
 
 # Build settings


### PR DESCRIPTION
Currently all the links from the atom feed point to 'yourdomain.com'; this change fixes that.